### PR TITLE
self.applyZoom fix - #29 

### DIFF
--- a/src/imageCropper.js
+++ b/src/imageCropper.js
@@ -121,10 +121,10 @@ Cropper.prototype.bindControls = function() {
     self.applyRotation(90);
   });
   this.elements.controls.zoomIn.addEventListener('click', function() {
-    self.applyZoom(self.zoomInFactor);
+    self.applyZoomIn(self.zoomInFactor);
   });
   this.elements.controls.zoomOut.addEventListener('click', function() {
-    self.applyZoom(self.zoomOutFactor);
+    self.applyZoomOut(self.zoomOutFactor);
   });
   this.elements.controls.fit.addEventListener('click', this.applyFit.bind(this));
   this.elements.controls.crop.addEventListener('click', this.cropImage.bind(this));


### PR DESCRIPTION
@bcabanes 

https://github.com/bcabanes/angular-image-cropper/issues/29

Applied fix suggested by **bigfree** in the issue above. 


previous
```
this.elements.controls.zoomIn.addEventListener('click', function() {
    self.applyZoom(self.zoomInFactor);
});
this.elements.controls.zoomOut.addEventListener('click', function() {
    self.applyZoom(self.zoomOutFactor);
});
```
changed to
```
this.elements.controls.zoomIn.addEventListener('click', function() {
    self.applyZoomIn(self.zoomInFactor);
});
this.elements.controls.zoomOut.addEventListener('click', function( {
    self.applyZoomOut(self.zoomOutFactor);
});
```